### PR TITLE
Add option to remove accessory side stepper notch when using Titan.

### DIFF
--- a/he_mount_generator.scad
+++ b/he_mount_generator.scad
@@ -565,6 +565,9 @@ e3dTitanMountBraceWidth = 2; // Width of the brace that stabilizes the E3D Titan
 e3dTitanMountBraceHeight = 5; // Height of brace.
 e3dTitanMountLowerOverlap = 15; // Amount the brace overlaps the main carriage.
 
+// Should a cut out be made for the extruder stepper?
+extruderStepper = "normal"; // [normal:Typical size, non-pancake, pancake:Pancake]
+
 /* [Hidden] */
 
 // E3D Titan settings
@@ -3025,8 +3028,8 @@ module cbot_carriage_holes(heSide=false) {
 	  }
      }
 
-     // Carve out space for the titan mount.
-     if (extruder == "titan") {
+     // Carve out space for the titan mount, if needed.
+     if ((extruder == "titan" && heSide == true) || (extruder == "titan" && heSide == false && extruderStepper != "pancake")) {
 	  translate([(heSide == true ? heAnchorL[0] : cBotCarriageWidth - heAnchorL[0]), - carriageDepth - .01, (cBotCarriageHeight + cBotTitanVertOffset)])
 	       translate([(heSide == true ? -(nema17OuterOffset + e3dTitanOffset[0]) : - (nema17OuterOffset - e3dTitanOffset[0])),0,0])
 	       cube([(nema17OuterOffset * 2) , carriageDepth + .02, (nema17OuterOffset * 2)]);


### PR DESCRIPTION
Allow option to keep accessory side carriage complete when using a
pancake stepper and an E3D Titan extruder.