### PR TITLE
Fixes for incorrect carriage height

### DIFF
--- a/he_mount_generator.scad
+++ b/he_mount_generator.scad
@@ -3060,14 +3060,10 @@ module cBot_cut_other_holes(heSide=false){
 	       }	       
 	  }
      }
-<<<<<<< HEAD
-     // Carve out space for the titan mount.
-     if (extruder == "titan") {
-=======
 
      // Carve out space for the titan mount, if needed.
      if ((extruder == "titan" && heSide == true) || (extruder == "titan" && heSide == false && extruderStepper != "pancake")) {
->>>>>>> refs/remotes/croadfeldt/master
+
 	  translate([(heSide == true ? heAnchorL[0] : cBotCarriageWidth - heAnchorL[0]), - carriageDepth - .01, (cBotCarriageHeight + cBotTitanVertOffset)])
 	       translate([(heSide == true ? -(nema17OuterOffset + e3dTitanOffset[0]) : - (nema17OuterOffset - e3dTitanOffset[0])),0,0])
 	       cube([(nema17OuterOffset * 2) , carriageDepth + .02, (nema17OuterOffset * 2)]);

--- a/he_mount_generator.scad
+++ b/he_mount_generator.scad
@@ -197,6 +197,9 @@ cBotXAxisSwitchTHOffset = 2.5;
 // Minimum width of carriage, will be increased if needed.
 cBotCarriageMinWidth = 40;
 
+// Amount of material around screw holes for carriage idler wheels.
+cBotCarriageIdlerScrewMat = 3.3;
+
 // Height of XY Bar .
 cBotXYBarHeight = 40;
 
@@ -204,10 +207,7 @@ cBotXYBarHeight = 40;
 cBotWheelOffsetFromBar = 10;
 
 // Height of carriage. Only changed if height of XY Bar is modified.
-cBotCarriageHeight=cBotXYBarHeight + (cBotWheelOffsetFromBar *2)+ 5;
-
-// Distance between wheel centres to add to height of XY bar (10mm for solid v-wheels, Unknown for mini wheels).
-cBotWheelOffsetFromBar = 10;
+cBotCarriageHeight=cBotXYBarHeight + (cBotWheelOffsetFromBar * 2) + (cBotCarriageIdlerScrewMat * 2);
 
 // Depth of carriage.
 cBotCarriageDepth = 5;
@@ -220,9 +220,6 @@ cBotNumberOfCarriageWheels = "4"; // [3:Three Wheels, 4:Four Wheels]
 
 // Diameter of screw holes for carriage eccentric spacer.
 cBotCarriageEccentricSpacerScrewDiameter = 7.2;
-
-// Amount of material around screw holes for carriage idler wheels.
-cBotCarriageIdlerScrewMat = 3.3;
 
 // Diameter of screw holes that mounts back plane to carriage.
 cBotCarriageMountScrewDiameter = 4.2;

--- a/he_mount_generator.scad
+++ b/he_mount_generator.scad
@@ -197,6 +197,9 @@ cBotXAxisSwitchTHOffset = 2.5;
 // Minimum width of carriage, will be increased if needed.
 cBotCarriageMinWidth = 40;
 
+// Should the carriage have 3 or 4 wheels?
+cBotNumberOfCarriageWheels = "4"; // [3:Three Wheels, 4:Four Wheels]
+
 // Amount of material around screw holes for carriage idler wheels.
 cBotCarriageIdlerScrewMat = 3.3;
 
@@ -206,17 +209,11 @@ cBotXYBarHeight = 40;
 // Distance between wheel centres to add to height of XY bar (10mm for solid v-wheels, Unknown for mini wheels).
 cBotWheelOffsetFromBar = 10;
 
-// Height of carriage. Only changed if height of XY Bar is modified.
-cBotCarriageHeight=cBotXYBarHeight + (cBotWheelOffsetFromBar * 2) + (cBotCarriageIdlerScrewMat * 2);
-
 // Depth of carriage.
 cBotCarriageDepth = 5;
 
 // Diameter of screw holes for carriage idler wheels.
 cBotCarriageIdlerScrewDiameter = 5.2;
-
-// Should the carriage have 3 or 4 wheels?
-cBotNumberOfCarriageWheels = "4"; // [3:Three Wheels, 4:Four Wheels]
 
 // Diameter of screw holes for carriage eccentric spacer.
 cBotCarriageEccentricSpacerScrewDiameter = 7.2;
@@ -547,7 +544,14 @@ echo("realFanDuctStyle", realFanDuctStyle);
 // Depth from center of hotend to face of carriage.
 jHeadMountDepth = 28.5; // Do not change this value, the direct drive extruders require this to be placed here and OpenSCAD programming makes it nearly impossible to auto adjust.
 
-/* [E3D V6 Advanced] */
+// Height of c-Bot carriage. 
+
+ cBot3WheelHeight = cBotXYBarHeight + (cBotWheelOffsetFromBar * 2) + (cBotCarriageIdlerScrewMat * 2) + (cBotCarriageIdlerScrewDiameter /2) + (cBotCarriageEccentricSpacerScrewDiameter /2);
+ cBot4WheelHeight = cBotXYBarHeight + (cBotWheelOffsetFromBar * 2) + (cBotCarriageIdlerScrewMat * 2) + (cBotCarriageIdlerScrewDiameter);
+ cBotCarriageHeight = (cBotNumberOfCarriageWheels == "3") ? cBot3WheelHeight : cBot4WheelHeight;
+ echo ("carriage height:",cBotCarriageHeight);
+
+ /* [E3D V6 Advanced] */
 
 // Variables for E3D V6
 v6NozzleL = [[0, 0, -62]]; // This must be a vector of vectors. If only one nozzle, enter x,y,z in [[ ]]
@@ -2423,7 +2427,6 @@ module servo_mount() {
 	   servoMountPlateHeight]);
 }
 
-
 module servo_mount_holes(cbot=false) {
      // Servo hole
      translate([-.1,
@@ -2801,6 +2804,7 @@ module cbot_carriage_side(heSide=false) {
 			}
 		}
 }
+
 module cbot_carriage_base() {
      // Base C Bot XY Carriage side.
      translate([cBotCarriageCornerRadius, 0, cBotCarriageCornerRadius])
@@ -2894,7 +2898,7 @@ module cbot_carriage_three_holes() {
 echo("cbot_carriage_three_holes");
      // Remove the holes for the carriage wheels.
 	 // Bottom, Middle with eccentric spacer.
-	 translate([cBotCarriageWidth/2,.1,cBotCarriageCornerRadius])
+	 translate([cBotCarriageWidth/2,.1,(cBotCarriageEccentricSpacerScrewDiameter/2)+cBotCarriageIdlerScrewMat ])//cBotCarriageCornerRadius])
 		rotate([90,0,0])
 		cylinder(d=cBotCarriageEccentricSpacerScrewDiameter, h=carriageDepth + .2, $fn=100);
      // Top left.


### PR DESCRIPTION
Carriage height was incorrect due to not taking into account the amount
of material around screw holes for the idler wheels.